### PR TITLE
qtchooser: fix endsWith() return value check bug; support more than one layer deep of sym links

### DIFF
--- a/src/qtchooser/main.cpp
+++ b/src/qtchooser/main.cpp
@@ -225,7 +225,7 @@ bool linksBackToSelf(const char *link, const char *target)
     int count = readlink(link, buf, sizeof(buf) - 1);
     if (count >= 0) {
         buf[count] = '\0';
-        if (endsWith(buf, target) == 0) {
+        if (endsWith(buf, target)) {
             fprintf(stderr, "%s: could not exec '%s' since it links to %s itself. Check your installation.\n",
                     target, link, target);
             return true;

--- a/src/qtchooser/main.cpp
+++ b/src/qtchooser/main.cpp
@@ -221,8 +221,8 @@ static inline bool endsWith(const char *haystack, const char *needle)
 bool linksBackToSelf(const char *link, const char *target)
 {
 #if !defined(_WIN32) && !defined(__WIN32__)
-    char buf[512];
-    int count = readlink(link, buf, sizeof(buf) - 1);
+    char buf[MAXPATHLEN], buf2[MAXPATHLEN];
+    int count = readlink(realpath(link, buf2), buf, sizeof(buf) - 1);
     if (count >= 0) {
         buf[count] = '\0';
         if (endsWith(buf, target)) {


### PR DESCRIPTION
See also https://bugreports.qt.io/browse/QTBUG-68857 for the endsWith() bug.